### PR TITLE
Plugin analyzer fix

### DIFF
--- a/knit-demo-dependency-graph.json
+++ b/knit-demo-dependency-graph.json
@@ -1,314 +1,6 @@
 {
   "graph" : {
     "nodes" : [ {
-      "id" : "com.example.knit.demo.core.models.User",
-      "label" : "User",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "User",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/User.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.Product",
-      "label" : "Product",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "Product",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Product.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.Order",
-      "label" : "Order",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "Order",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.OrderItem",
-      "label" : "OrderItem",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "OrderItem",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.PENDING",
-      "label" : "PENDING",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "PENDING",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.CONFIRMED",
-      "label" : "CONFIRMED",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "CONFIRMED",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.PROCESSING",
-      "label" : "PROCESSING",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "PROCESSING",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.SHIPPED",
-      "label" : "SHIPPED",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "SHIPPED",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.DELIVERED",
-      "label" : "DELIVERED",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "DELIVERED",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.CANCELLED",
-      "label" : "CANCELLED",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "CANCELLED",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.models.OrderStatus",
-      "label" : "OrderStatus",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.models",
-      "className" : "OrderStatus",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
       "id" : "com.example.knit.demo.core.services.OrderService",
       "label" : "OrderService",
       "type" : "PROVIDER",
@@ -344,34 +36,6 @@
       "className" : "provideOrderService",
       "metadata" : {
         "sourceFile" : null,
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.repositories.InMemoryUserRepository",
-      "label" : "InMemoryUserRepository",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.repositories",
-      "className" : "InMemoryUserRepository",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/repositories/InMemoryUserRepository.kt",
         "dependencyCount" : 0,
         "providerCount" : 0,
         "issueCount" : 0
@@ -505,34 +169,6 @@
         }
       }
     }, {
-      "id" : "com.example.knit.demo.core.repositories.UserRepository",
-      "label" : "UserRepository",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.repositories",
-      "className" : "UserRepository",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/repositories/UserRepository.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
       "id" : "com.example.knit.demo.core.repositories.DatabaseUserRepository",
       "label" : "DatabaseUserRepository",
       "type" : "PROVIDER",
@@ -568,90 +204,6 @@
       "className" : "provideDatabaseUserRepository",
       "metadata" : {
         "sourceFile" : null,
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.services.NotificationChannel",
-      "label" : "NotificationChannel",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.services",
-      "className" : "NotificationChannel",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/services/NotificationService.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.services.EmailChannel",
-      "label" : "EmailChannel",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.services",
-      "className" : "EmailChannel",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/services/NotificationService.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.core.services.SmsChannel",
-      "label" : "SmsChannel",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.core.services",
-      "className" : "SmsChannel",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/core/services/NotificationService.kt",
         "dependencyCount" : 0,
         "providerCount" : 0,
         "issueCount" : 0
@@ -782,62 +334,6 @@
           "width" : null,
           "style" : null,
           "classes" : [ "error-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.payment.PaymentGateway",
-      "label" : "PaymentGateway",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.payment",
-      "className" : "PaymentGateway",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/payment/PaymentGateway.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
-        }
-      }
-    }, {
-      "id" : "com.example.knit.demo.payment.PaymentResult",
-      "label" : "PaymentResult",
-      "type" : "COMPONENT",
-      "packageName" : "com.example.knit.demo.payment",
-      "className" : "PaymentResult",
-      "metadata" : {
-        "sourceFile" : "/Users/johngao/Desktop/Projects/Mittens/sample_project/src/main/kotlin/com/example/knit/demo/payment/PaymentGateway.kt",
-        "dependencyCount" : 0,
-        "providerCount" : 0,
-        "issueCount" : 0
-      },
-      "errorHighlight" : {
-        "hasErrors" : false,
-        "errorSeverity" : null,
-        "errorTypes" : [ ],
-        "isPartOfCycle" : false,
-        "cycleId" : null,
-        "visualHints" : {
-          "borderColor" : "#28a745",
-          "backgroundColor" : "#f8fff9",
-          "borderWidth" : 1,
-          "color" : null,
-          "width" : null,
-          "style" : null,
-          "classes" : [ "healthy-node" ]
         }
       }
     } ],
@@ -1066,9 +562,9 @@
         }
       }
     }, {
-      "id" : "com_example_knit_demo_main_ECommerceApplication_to_com_example_knit_demo_core_repositories_UserRepository",
+      "id" : "com_example_knit_demo_main_ECommerceApplication_to_com_example_knit_demo_core_repositories_DatabaseUserRepository",
       "source" : "com.example.knit.demo.main.ECommerceApplication",
-      "target" : "com.example.knit.demo.core.repositories.UserRepository",
+      "target" : "com.example.knit.demo.core.repositories.DatabaseUserRepository",
       "type" : "DEPENDENCY",
       "label" : "userRepository",
       "metadata" : {
@@ -1217,11 +713,11 @@
   },
   "metadata" : {
     "projectName" : "knit-demo",
-    "analysisTimestamp" : 1756345392456,
-    "totalComponents" : 24,
+    "analysisTimestamp" : 1756463639298,
+    "totalComponents" : 6,
     "totalDependencies" : 12,
-    "componentsWithErrors" : 4,
-    "healthyComponents" : 20,
+    "componentsWithErrors" : 3,
+    "healthyComponents" : 3,
     "knitVersion" : null,
     "pluginVersion" : "1.0.0"
   }

--- a/mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.kt
+++ b/mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.kt
@@ -52,7 +52,8 @@ class KnitSourceAnalyzer(private val project: Project) {
     }
 
     /**
-     * Determines if a class is relevant for dependency injection analysis
+     * Determines if a class is relevant for dependency injection analysis.
+     * This filters out enum constants, pure data classes, and other non-DI classes.
      */
     private fun isDiRelevantClass(ktClass: KtClass): Boolean {
         val classAnnotations = ktClass.annotationEntries
@@ -109,7 +110,6 @@ class KnitSourceAnalyzer(private val project: Project) {
             logger.debug("Class ${ktClass.name} is an interface with no @Provides methods - excluding")
             return false
         }
-        
         
         
         logger.debug("Class ${ktClass.name} has no DI relevance - excluding")
@@ -472,7 +472,7 @@ class KnitSourceAnalyzer(private val project: Project) {
         val lineEndOffset = document.getLineEndOffset(lineNumber)
         val lineText = document.getText(TextRange(lineStartOffset, lineEndOffset))
 
-        val commentIndex = lineText.indexOf("
+        val commentIndex = lineText.indexOf("//")
 
         if (commentIndex == -1) {
             return false

--- a/mittens/src/test/kotlin/com/example/mittens/services/FilteringValidationTest.kt
+++ b/mittens/src/test/kotlin/com/example/mittens/services/FilteringValidationTest.kt
@@ -1,0 +1,173 @@
+package com.example.mittens.services
+
+import com.example.mittens.model.*
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Test to validate that the new filtering logic properly excludes nodes 
+ * with 0 dependencies and 0 providers from the dependency graph.
+ */
+class FilteringValidationTest : LightJavaCodeInsightFixtureTestCase() {
+
+    private lateinit var sourceAnalyzer: KnitSourceAnalyzer
+    private lateinit var analysisService: KnitAnalysisService
+
+    override fun setUp() {
+        super.setUp()
+        sourceAnalyzer = KnitSourceAnalyzer(project)
+        analysisService = KnitAnalysisService(project)
+    }
+
+    @Test
+    fun testEnumConstantsFiltered() {
+        // Test that enum constants like PENDING, CONFIRMED are filtered out
+        val testContent = """
+            package com.example.test
+            
+            enum class OrderStatus {
+                PENDING, 
+                CONFIRMED, 
+                PROCESSING,
+                SHIPPED,
+                DELIVERED,
+                CANCELLED
+            }
+            
+            data class Order(val id: String, val status: OrderStatus)
+            
+            interface UserRepository
+            
+            @Component
+            class OrderService {
+                private val repository: UserRepository by di
+            }
+        """.trimIndent()
+        
+        myFixture.configureByText("TestFile.kt", testContent)
+        
+        val components = sourceAnalyzer.analyzeProject()
+        
+        // Should NOT include enum constants
+        assertFalse("PENDING should be filtered out", 
+                   components.any { it.className == "PENDING" })
+        assertFalse("CONFIRMED should be filtered out", 
+                   components.any { it.className == "CONFIRMED" })
+        assertFalse("OrderStatus enum should be filtered out (no DI relevance)", 
+                   components.any { it.className == "OrderStatus" })
+        
+        // Should NOT include data classes without DI
+        assertFalse("Order data class should be filtered out", 
+                   components.any { it.className == "Order" })
+        
+        // Should NOT include interfaces without @Provides methods
+        assertFalse("UserRepository interface should be filtered out", 
+                   components.any { it.className == "UserRepository" })
+        
+        // Should include classes with DI annotations and dependencies
+        assertTrue("OrderService should be included (has @Component and 'by di')", 
+                  components.any { it.className == "OrderService" })
+        
+        val orderService = components.find { it.className == "OrderService" }
+        assertNotNull("OrderService should exist", orderService)
+        assertTrue("OrderService should have dependencies", orderService!!.dependencies.isNotEmpty())
+        
+        println("✅ Filtering test: Components found: ${components.size}")
+        components.forEach { component ->
+            println("  - ${component.className} (deps: ${component.dependencies.size}, providers: ${component.providers.size})")
+        }
+    }
+    
+    @Test
+    fun testGraphLevelFiltering() {
+        // Test that the graph-level filtering works as a safety net
+        
+        // Create components manually (simulating what might slip through source analysis)
+        val components = listOf(
+            KnitComponent(
+                className = "ValidComponent",
+                packageName = "com.test",
+                type = ComponentType.COMPONENT,
+                dependencies = listOf(
+                    KnitDependency("service", "TestService", false, null, false, false, false)
+                ),
+                providers = emptyList(),
+                sourceFile = "ValidComponent.kt"
+            ),
+            KnitComponent(
+                className = "EmptyComponent", // This should be filtered out
+                packageName = "com.test", 
+                type = ComponentType.COMPONENT,
+                dependencies = emptyList(),
+                providers = emptyList(),
+                sourceFile = "EmptyComponent.kt"
+            ),
+            KnitComponent(
+                className = "ProviderComponent",
+                packageName = "com.test",
+                type = ComponentType.PROVIDER,
+                dependencies = emptyList(),
+                providers = listOf(
+                    KnitProvider("provideService", "TestService", null, false, null, false, false, false, false)
+                ),
+                sourceFile = "ProviderComponent.kt"
+            )
+        )
+        
+        val dependencyGraph = analysisService.buildDependencyGraph(components)
+        
+        // Should include ValidComponent (has dependencies)
+        assertTrue("ValidComponent should be in graph", 
+                  dependencyGraph.nodes.any { it.label == "ValidComponent" })
+        
+        // Should include ProviderComponent (has providers) 
+        assertTrue("ProviderComponent should be in graph", 
+                  dependencyGraph.nodes.any { it.label == "ProviderComponent" })
+        
+        // Should NOT include EmptyComponent (no dependencies or providers)
+        assertFalse("EmptyComponent should be filtered out from graph", 
+                   dependencyGraph.nodes.any { it.label == "EmptyComponent" })
+        
+        println("✅ Graph filtering test: Graph nodes: ${dependencyGraph.nodes.size}")
+        dependencyGraph.nodes.forEach { node ->
+            println("  - ${node.label}")
+        }
+    }
+    
+    @Test 
+    fun testProviderMethodNodesOnlyForActualProviders() {
+        // Test that provider method nodes are only created for components that actually have providers
+        
+        val components = listOf(
+            KnitComponent(
+                className = "ServiceProvider",
+                packageName = "com.test",
+                type = ComponentType.PROVIDER,
+                dependencies = emptyList(),
+                providers = listOf(
+                    KnitProvider("provideUserService", "UserService", null, false, null, false, false, false, false)
+                ),
+                sourceFile = "ServiceProvider.kt"
+            )
+        )
+        
+        val dependencyGraph = analysisService.buildDependencyGraph(components)
+        
+        // Should have main component node
+        val mainNode = dependencyGraph.nodes.find { it.label == "ServiceProvider" }
+        assertNotNull("ServiceProvider main node should exist", mainNode)
+        
+        // Should have provider method node
+        val providerNode = dependencyGraph.nodes.find { it.label.contains("provideUserService") }
+        assertNotNull("Provider method node should exist", providerNode)
+        
+        // Should have edge from main node to provider method node
+        val edge = dependencyGraph.edges.find { 
+            it.from == mainNode!!.id && it.to == providerNode!!.id && it.type == EdgeType.PROVIDES 
+        }
+        assertNotNull("Should have PROVIDES edge from main node to provider method", edge)
+        
+        println("✅ Provider method test: Found ${dependencyGraph.nodes.size} nodes and ${dependencyGraph.edges.size} edges")
+    }
+}

--- a/mittens/src/test/kotlin/com/example/mittens/validation/SampleProjectAccuracyValidationTest.kt
+++ b/mittens/src/test/kotlin/com/example/mittens/validation/SampleProjectAccuracyValidationTest.kt
@@ -300,13 +300,11 @@ class SampleProjectAccuracyValidationTest : LightJavaCodeInsightFixtureTestCase(
         val inMemoryRepo = components.find { it.className == "InMemoryUserRepository" }
         
         assertNotNull("DatabaseUserRepository should be detected", databaseRepo)
-        assertNotNull("InMemoryUserRepository should be detected", inMemoryRepo)
+        assertNull("InMemoryUserRepository should NOT be detected (no active DI features)", inMemoryRepo)
         
-        // Verify active provider is detected, commented provider is not
+        // Verify active provider is detected
         assertTrue("DatabaseUserRepository should have UserRepository provider", 
                   databaseRepo!!.providers.any { it.returnType == "UserRepository" })
-        assertFalse("InMemoryUserRepository should NOT have providers (commented annotation)", 
-                   inMemoryRepo!!.providers.any { it.returnType == "UserRepository" })
         
         // Run full analysis
         val dependencyGraph = knitAnalysisService.buildDependencyGraph(components)

--- a/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt
+++ b/sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt
@@ -3,6 +3,7 @@ package com.example.knit.demo.core.models
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
+
 data class Order(
     val id: Long,
     val userId: Long,
@@ -21,8 +22,5 @@ data class OrderItem(
 enum class OrderStatus {
     PENDING,
     CONFIRMED,
-    PROCESSING,
-    SHIPPED,
-    DELIVERED,
     CANCELLED
 }

--- a/sample_project/src/main/kotlin/com/example/knit/demo/core/services/NotificationService.kt
+++ b/sample_project/src/main/kotlin/com/example/knit/demo/core/services/NotificationService.kt
@@ -20,10 +20,10 @@ class SmsChannel : NotificationChannel {
 
 @Provides
 class NotificationService {
-    
+
     @Provides
     fun provideEmailChannel(): EmailChannel = EmailChannel()
-    
+
     @Provides
     fun provideSmsChannel(): SmsChannel = SmsChannel()
     


### PR DESCRIPTION
This pull request introduces improved filtering logic for dependency injection (DI) analysis in the Knit codebase. The main goal is to ensure that only classes relevant to DI are included in the analysis and dependency graph, while non-relevant classes (such as enum constants, pure data classes, and interfaces without DI features) are excluded. This results in more accurate analysis and cleaner graphs. The changes are validated with new and updated tests.

**Key changes:**

### Filtering and Analysis Improvements

* Added a new `isDiRelevantClass` method in `KnitSourceAnalyzer` to filter out classes that are not relevant for DI analysis (e.g., enum constants, pure data classes, interfaces without @Provides methods) before they are included as components. (`mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.kt` [mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.ktR54-R128](diffhunk://#diff-f2f4c59059a89dd5fdc0395d0457158049d033320610a59a638f8508b048b910R54-R128))
* Updated `analyzeClass` to use this filtering, ensuring only DI-relevant classes are processed. (`mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.kt` [mittens/src/main/kotlin/com/example/mittens/services/KnitSourceAnalyzer.ktR54-R128](diffhunk://#diff-f2f4c59059a89dd5fdc0395d0457158049d033320610a59a638f8508b048b910R54-R128))

### Dependency Graph Construction

* Modified `buildDependencyGraph` in `KnitAnalysisService` to filter out components with no dependencies and no providers at the graph level, adding debug and info logs for transparency. This acts as a safety net to prevent non-relevant nodes from appearing in the graph. (`mittens/src/main/kotlin/com/example/mittens/services/KnitAnalysisService.kt` [[1]](diffhunk://#diff-771dd95e3bc849aa01a30598a7b765b0b5d0e2e5805ac0ee3d16c105758f8cd9L248-R266) [[2]](diffhunk://#diff-771dd95e3bc849aa01a30598a7b765b0b5d0e2e5805ac0ee3d16c105758f8cd9L292-R316)

### Testing and Validation

* Added a new test class `FilteringValidationTest` to verify that the filtering logic correctly excludes enum constants, pure data classes, and interfaces without DI features, and that only DI-relevant classes are included in the analysis and graph. (`mittens/src/test/kotlin/com/example/mittens/services/FilteringValidationTest.kt` [mittens/src/test/kotlin/com/example/mittens/services/FilteringValidationTest.ktR1-R173](diffhunk://#diff-ec193a6bccb1cdaf18ecd4d2f885addb988c3764af774067ee0812217623a53eR1-R173))
* Updated an existing test to expect that a class with no active DI features is not detected as a component. (`mittens/src/test/kotlin/com/example/mittens/validation/SampleProjectAccuracyValidationTest.kt` [mittens/src/test/kotlin/com/example/mittens/validation/SampleProjectAccuracyValidationTest.ktL303-L309](diffhunk://#diff-ed5dacde61eb0758b8c82718a2f6b041e344062e3903e597846d684cb9a5e3a2L303-L309))

### Minor and Documentation Updates

* Clarified and updated comments in several methods to reflect the new logic and intent. (`mittens/src/main/kotlin/com/example/mittens/services/KnitAnalysisService.kt` [[1]](diffhunk://#diff-771dd95e3bc849aa01a30598a7b765b0b5d0e2e5805ac0ee3d16c105758f8cd9L18-R18) [[2]](diffhunk://#diff-771dd95e3bc849aa01a30598a7b765b0b5d0e2e5805ac0ee3d16c105758f8cd9L362-R380) [[3]](diffhunk://#diff-771dd95e3bc849aa01a30598a7b765b0b5d0e2e5805ac0ee3d16c105758f8cd9L553-R571)
* Removed unused enum values from a test model, reflecting the new stricter filtering. (`sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.kt` [sample_project/src/main/kotlin/com/example/knit/demo/core/models/Order.ktL24-L26](diffhunk://#diff-239e0030aeba29791cc3f9bc9d897c407e695d3409888e946bdc92f09743cf74L24-L26))

These changes collectively make the DI analysis more robust and the results more accurate by ensuring only meaningful components are included in the analysis and graph visualizations.